### PR TITLE
Parse simple import statement

### DIFF
--- a/dart-parser/src/dart.rs
+++ b/dart-parser/src/dart.rs
@@ -7,7 +7,16 @@ pub use class_modifier::*;
 #[derive(PartialEq, Eq, Debug)]
 pub enum Dart<'s> {
     Verbatim(&'s str),
+    Import(Import<'s>),
     Class(Class<'s>),
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct Import<'s> {
+    pub target: &'s str,
+    // pub prefix: &str,
+    // pub show: Vec<&str>,
+    // pub hide: Vec<&str>,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/reptr/src/main.rs
+++ b/reptr/src/main.rs
@@ -95,7 +95,7 @@ fn try_mmap_parse(path: &Path) -> io::Result<()> {
     let content =
         std::str::from_utf8(&content).map_err(|err| io::Error::new(io::ErrorKind::Other, err))?;
     // let content = unsafe { std::str::from_utf8_unchecked(&content) };
-    let (_, _items) = dart_parser::parse(&content)
+    let _items = dart_parser::parse(&content)
         .map_err(|err| io::Error::new(io::ErrorKind::Other, err.to_string()))
         .context_lazy(|| format!("Cannot parse file at path {path:?}"))?;
 


### PR DESCRIPTION
Parse simple import statements (without `as`, `show`, or `hide` clauses).

The import target is parsed as a simplified single- or double-quoted string without escape sequences or string interpolation.

Resolves #8 