### PR TITLE
Parse an identifier with type arguments

### DIFF
--- a/dart-parser/src/dart.rs
+++ b/dart-parser/src/dart.rs
@@ -23,7 +23,22 @@ pub struct Import<'s> {
 pub struct Class<'s> {
     pub modifiers: ClassModifierSet,
     pub name: &'s str,
-    pub extends: Option<&'s str>,
-    pub implements: Vec<&'s str>,
+    pub extends: Option<IdentifierExt<'s>>,
+    pub implements: Vec<IdentifierExt<'s>>,
     pub body: &'s str,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct IdentifierExt<'s> {
+    pub name: &'s str,
+    pub type_args: Vec<IdentifierExt<'s>>,
+}
+
+impl<'s> IdentifierExt<'s> {
+    pub fn name(name: &'s str) -> Self {
+        Self {
+            name,
+            type_args: Vec::default(),
+        }
+    }
 }

--- a/dart-parser/src/parser.rs
+++ b/dart-parser/src/parser.rs
@@ -95,8 +95,8 @@ mod tests {
                     Dart::Class(Class {
                         modifiers: ClassModifierSet::from_iter([ClassModifier::Class]),
                         name: "Record",
-                        extends: Some("Base"),
-                        implements: vec!["A", "B"],
+                        extends: Some(IdentifierExt::name("Base")),
+                        implements: vec![IdentifierExt::name("A"), IdentifierExt::name("B")],
                         body: "{\n  String name;\n}",
                     }),
                     Dart::Verbatim("\n")

--- a/dart-parser/src/parser/common.rs
+++ b/dart-parser/src/parser/common.rs
@@ -2,11 +2,13 @@ use nom::{
     branch::alt,
     bytes::complete::{is_a, is_not, tag, take_while, take_while_m_n},
     character::complete::char,
-    combinator::recognize,
-    multi::many0,
-    sequence::{delimited, pair},
-    IResult,
+    combinator::{cut, opt, recognize},
+    multi::{many0, separated_list1},
+    sequence::{delimited, pair, preceded, tuple},
+    IResult, Parser,
 };
+
+use crate::dart::IdentifierExt;
 
 /// Parse one or more whitespace characters, excluding line breaks.
 pub fn sp(s: &str) -> IResult<&str, &str> {
@@ -38,6 +40,28 @@ pub fn identifier(s: &str) -> IResult<&str, &str> {
     ))(s)
 }
 
+pub fn identifier_ext(s: &str) -> IResult<&str, IdentifierExt> {
+    pair(
+        identifier,
+        opt(preceded(
+            opt(spbr),
+            delimited(
+                pair(tag("<"), opt(spbr)),
+                cut(separated_list1(
+                    tuple((opt(spbr), tag(","), opt(spbr))),
+                    identifier_ext,
+                )),
+                cut(pair(opt(spbr), tag(">"))),
+            ),
+        )),
+    )
+    .map(|(name, args)| IdentifierExt {
+        name,
+        type_args: args.unwrap_or(Vec::default()),
+    })
+    .parse(s)
+}
+
 pub fn block(s: &str) -> IResult<&str, &str> {
     recognize(delimited(
         char('{'),
@@ -54,5 +78,39 @@ mod tests {
     fn sp_test() {
         let s = "  \n\t\r\nx";
         assert_eq!(spbr(s), Ok(("x", "  \n\t\r\n")));
+    }
+
+    #[test]
+    fn identifier_ext_test() {
+        assert_eq!(
+            identifier_ext("Map<String, Object> "),
+            Ok((
+                " ",
+                IdentifierExt {
+                    name: "Map",
+                    type_args: vec![IdentifierExt::name("String"), IdentifierExt::name("Object"),]
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn identifier_ext_nested_test() {
+        assert_eq!(
+            identifier_ext("Map<String, List<int>> "),
+            Ok((
+                " ",
+                IdentifierExt {
+                    name: "Map",
+                    type_args: vec![
+                        IdentifierExt::name("String"),
+                        IdentifierExt {
+                            name: "List",
+                            type_args: vec![IdentifierExt::name("int")]
+                        }
+                    ]
+                }
+            ))
+        );
     }
 }


### PR DESCRIPTION
Parse an identifier with type arguments and allow type arguments in class extends and implements clauses.

Resolves #15 