### PR TITLE
Parse positional function parameters

### DIFF
--- a/dart-parser/src/dart/func.rs
+++ b/dart-parser/src/dart/func.rs
@@ -8,7 +8,7 @@ pub struct Func<'s> {
     pub return_type: IdentifierExt<'s>,
     pub name: &'s str,
     // pub type_params: Vec<_>,
-    // pub params: Vec<_>,
+    pub params: FuncParams<'s>,
     pub body: Option<FuncBody<'s>>,
 }
 
@@ -18,6 +18,29 @@ pub struct Func<'s> {
 pub enum FuncModifier {
     External,
     Static,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct FuncParams<'s> {
+    pub positional: Vec<FuncParam<'s>>,
+    pub named: Vec<FuncParam<'s>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct FuncParam<'s> {
+    pub is_required: bool,
+    pub modifiers: FuncParamModifierSet,
+    pub param_type: Option<IdentifierExt<'s>>,
+    pub name: &'s str,
+    pub initializer: Option<&'s str>,
+}
+
+#[with_tiny_set]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+#[repr(usize)]
+pub enum FuncParamModifier {
+    Covariant,
+    Final,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/dart-parser/src/parser.rs
+++ b/dart-parser/src/parser.rs
@@ -130,7 +130,47 @@ mod tests {
                         ],
                         body: "{\n  String name;\n}",
                     }),
-                    Dart::Verbatim("\n")
+                    Dart::Verbatim("\n\n"),
+                    Dart::Func(Func {
+                        modifiers: FuncModifierSet::default(),
+                        return_type: IdentifierExt {
+                            name: "Map",
+                            type_args: vec![
+                                IdentifierExt::name("String"),
+                                IdentifierExt {
+                                    name: "Object",
+                                    type_args: Vec::new(),
+                                    is_nullable: true,
+                                }
+                            ],
+                            is_nullable: false,
+                        },
+                        name: "_recordToJson",
+                        params: FuncParams {
+                            positional: vec![
+                                FuncParam {
+                                    is_required: true,
+                                    modifiers: FuncParamModifierSet::default(),
+                                    param_type: Some(IdentifierExt::name("Record")),
+                                    name: "o",
+                                    initializer: None,
+                                },
+                                FuncParam {
+                                    is_required: false,
+                                    modifiers: FuncParamModifierSet::default(),
+                                    param_type: Some(IdentifierExt::name("bool")),
+                                    name: "quack",
+                                    initializer: Some("false")
+                                }
+                            ],
+                            named: Vec::new(),
+                        },
+                        body: Some(FuncBody {
+                            modifiers: FuncBodyModifierSet::default(),
+                            content: FuncBodyContent::Block("{\n    print(\"Hello?\");\n}")
+                        })
+                    }),
+                    Dart::Verbatim("\n"),
                 ]
             ))
         );
@@ -153,6 +193,10 @@ class Base {
 
 class Record extends Base implements A<Future<void>, B?>, C {
   String name;
+}
+
+Map<String, Object?> _recordToJson(Record o, [bool quack = false]) {
+    print("Hello?");
 }
 "#;
 }

--- a/dart-parser/src/parser/func.rs
+++ b/dart-parser/src/parser/func.rs
@@ -2,6 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::tag,
     combinator::{cut, fail, opt, success, value},
+    error::context,
     multi::{fold_many0, separated_list0, separated_list1},
     sequence::{pair, preceded, terminated, tuple},
     Parser,
@@ -9,7 +10,7 @@ use nom::{
 
 use crate::dart::{
     Func, FuncBody, FuncBodyContent, FuncBodyModifier, FuncBodyModifierSet, FuncModifier,
-    FuncModifierSet,
+    FuncModifierSet, FuncParam, FuncParamModifier, FuncParamModifierSet, FuncParams,
 };
 
 use super::{
@@ -20,29 +21,31 @@ use super::{
 };
 
 pub fn func(s: &str) -> PResult<Func> {
-    tuple((
-        alt((
-            terminated(func_modifier_set, spbr),
-            success(FuncModifierSet::default()),
-        )),
-        identifier_ext,
-        preceded(opt(spbr), identifier),
-        opt(preceded(opt(spbr), type_params)),
-        preceded(opt(spbr), func_params),
-        alt((
-            preceded(opt(spbr), func_body).map(Some),
-            pair(opt(spbr), tag(";")).map(|_| None),
-        )),
-    ))
-    .map(
-        |(modifiers, return_type, name, _type_params, _params, body)| Func {
-            modifiers,
-            return_type,
-            name,
-            // type_params,
-            // params,
-            body,
-        },
+    context(
+        "func",
+        tuple((
+            alt((
+                terminated(func_modifier_set, spbr),
+                success(FuncModifierSet::default()),
+            )),
+            // Return type
+            terminated(identifier_ext, opt(spbr)),
+            // Function name
+            terminated(identifier, opt(spbr)),
+            opt(terminated(type_params, opt(spbr))),
+            terminated(func_params, opt(spbr)),
+            alt((func_body.map(Some), tag(";").map(|_| None))),
+        ))
+        .map(
+            |(modifiers, return_type, name, _type_params, params, body)| Func {
+                modifiers,
+                return_type,
+                name,
+                // type_params,
+                params,
+                body,
+            },
+        ),
     )
     .parse(s)
 }
@@ -67,12 +70,15 @@ fn func_modifier(s: &str) -> PResult<FuncModifier> {
 }
 
 fn type_params(s: &str) -> PResult<Vec<()>> {
-    preceded(
-        pair(tag("<"), opt(spbr)),
-        cut(terminated(
-            separated_list1(tuple((opt(spbr), tag(","), opt(spbr))), type_param),
-            pair(opt(spbr), tag(">")),
-        )),
+    context(
+        "type_params",
+        preceded(
+            pair(tag("<"), opt(spbr)),
+            cut(terminated(
+                separated_list1(tuple((opt(spbr), tag(","), opt(spbr))), type_param),
+                pair(opt(spbr), tag(">")),
+            )),
+        ),
     )(s)
 }
 
@@ -80,18 +86,117 @@ fn type_param(s: &str) -> PResult<()> {
     fail(s)
 }
 
-fn func_params(s: &str) -> PResult<Vec<()>> {
-    preceded(
-        pair(tag("("), opt(spbr)),
-        cut(terminated(
-            separated_list0(tuple((opt(spbr), tag(","), opt(spbr))), func_param),
-            pair(opt(spbr), tag(")")),
+fn func_params(s: &str) -> PResult<FuncParams> {
+    context(
+        "func_params",
+        preceded(
+            pair(tag("("), opt(spbr)),
+            cut(terminated(
+                pair(
+                    terminated(func_params_pos, opt(spbr)),
+                    opt(terminated(func_params_named, opt(spbr))),
+                ),
+                pair(opt(spbr), tag(")")),
+            )),
+        )
+        .map(|(positional, named)| FuncParams {
+            positional,
+            named: named.unwrap_or(Vec::new()),
+        }),
+    )
+    .parse(s)
+}
+
+fn func_params_pos(s: &str) -> PResult<Vec<FuncParam>> {
+    pair(
+        terminated(
+            separated_list0(
+                tuple((opt(spbr), tag(","), opt(spbr))),
+                func_param_pos(true),
+            ),
+            opt(tuple((opt(spbr), tag(","), opt(spbr)))),
+        ),
+        opt(preceded(
+            pair(tag("["), opt(spbr)),
+            terminated(
+                separated_list0(
+                    tuple((opt(spbr), tag(","), opt(spbr))),
+                    func_param_pos(false),
+                ),
+                tuple((opt(spbr), opt(pair(tag(","), opt(spbr))), tag("]"))),
+            ),
         )),
+    )
+    .map(|(mut req, opt)| {
+        if let Some(mut opt) = opt {
+            req.append(&mut opt);
+        }
+
+        req
+    })
+    .parse(s)
+}
+
+fn func_param_pos(is_required: bool) -> impl FnMut(&str) -> PResult<FuncParam> {
+    move |s| {
+        context(
+            "func_param_pos",
+            tuple((
+                alt((
+                    terminated(func_param_modifier_set, spbr),
+                    success(FuncParamModifierSet::default()),
+                )),
+                opt(terminated(tag("var"), spbr)),
+                alt((
+                    // A type followed by a name
+                    pair(
+                        terminated(identifier_ext, opt(spbr)).map(Some),
+                        terminated(identifier, opt(spbr)),
+                    ),
+                    // Just a name
+                    terminated(identifier, opt(spbr)).map(|id| (None, id)),
+                )),
+                // An initializer
+                opt(preceded(
+                    pair(tag("="), opt(spbr)),
+                    cut(terminated(expr, opt(spbr))),
+                )),
+            ))
+            .map(
+                |(modifiers, _, (param_type, name), initializer)| FuncParam {
+                    is_required,
+                    modifiers,
+                    param_type,
+                    name,
+                    initializer,
+                },
+            ),
+        )
+        .parse(s)
+    }
+}
+
+fn func_params_named(s: &str) -> PResult<Vec<FuncParam>> {
+    fail(s)
+}
+
+fn func_param_modifier_set(s: &str) -> PResult<FuncParamModifierSet> {
+    let (s, modifier) = func_param_modifier(s)?;
+
+    let modifiers = FuncParamModifierSet::from_iter([modifier]);
+
+    fold_many0(
+        preceded(spbr, func_param_modifier),
+        move || modifiers,
+        |modifiers, modifier| modifiers.with(modifier),
     )(s)
 }
 
-fn func_param(s: &str) -> PResult<()> {
-    fail(s)
+fn func_param_modifier(s: &str) -> PResult<FuncParamModifier> {
+    alt((
+        value(FuncParamModifier::Covariant, tag("covariant")),
+        value(FuncParamModifier::Final, tag("final")),
+    ))(s)
 }
 
 fn func_body(s: &str) -> PResult<FuncBody> {
@@ -113,7 +218,7 @@ fn func_body_content(s: &str) -> PResult<FuncBodyContent> {
             terminated(expr, pair(opt(spbr), tag(";"))),
         )
         .map(FuncBodyContent::Expr),
-        preceded(opt(spbr), block).map(FuncBodyContent::Block),
+        block.map(FuncBodyContent::Block),
     ))(s)
 }
 
@@ -159,6 +264,63 @@ mod tests {
                     modifiers: FuncModifierSet::default(),
                     return_type: IdentifierExt::name("void"),
                     name: "f",
+                    params: FuncParams {
+                        positional: Vec::new(),
+                        named: Vec::new(),
+                    },
+                    body: Some(FuncBody {
+                        modifiers: FuncBodyModifierSet::default(),
+                        content: FuncBodyContent::Block("{}")
+                    })
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn func_pos_params_test() {
+        assert_eq!(
+            func("void f(int x, final double? y, [final bool mystery_flag = false]) {}x"),
+            Ok((
+                "x",
+                Func {
+                    modifiers: FuncModifierSet::default(),
+                    return_type: IdentifierExt::name("void"),
+                    name: "f",
+                    params: FuncParams {
+                        positional: vec![
+                            FuncParam {
+                                is_required: true,
+                                modifiers: FuncParamModifierSet::default(),
+                                param_type: Some(IdentifierExt::name("int")),
+                                name: "x",
+                                initializer: None,
+                            },
+                            FuncParam {
+                                is_required: true,
+                                modifiers: FuncParamModifierSet::from_iter([
+                                    FuncParamModifier::Final
+                                ]),
+                                param_type: Some(IdentifierExt {
+                                    name: "double",
+                                    type_args: Vec::new(),
+                                    is_nullable: true,
+                                }),
+                                name: "y",
+                                initializer: None,
+                            },
+                            FuncParam {
+                                is_required: false,
+                                modifiers: FuncParamModifierSet::from_iter([
+                                    FuncParamModifier::Final
+                                ]),
+                                param_type: Some(IdentifierExt::name("bool",)),
+                                name: "mystery_flag",
+                                initializer: Some("false"),
+                            }
+                        ],
+                        named: Vec::new(),
+                    },
                     body: Some(FuncBody {
                         modifiers: FuncBodyModifierSet::default(),
                         content: FuncBodyContent::Block("{}")
@@ -182,6 +344,10 @@ mod tests {
                         is_nullable: false
                     },
                     name: "f",
+                    params: FuncParams {
+                        positional: Vec::new(),
+                        named: Vec::new(),
+                    },
                     body: Some(FuncBody {
                         modifiers: FuncBodyModifierSet::from_iter([
                             FuncBodyModifier::SyncGenerator
@@ -207,6 +373,10 @@ mod tests {
                         is_nullable: false,
                     },
                     name: "f",
+                    params: FuncParams {
+                        positional: Vec::new(),
+                        named: Vec::new(),
+                    },
                     body: Some(FuncBody {
                         modifiers: FuncBodyModifierSet::default(),
                         content: FuncBodyContent::Expr("const [\"abc\"]")
@@ -230,6 +400,10 @@ mod tests {
                         is_nullable: false,
                     },
                     name: "f",
+                    params: FuncParams {
+                        positional: Vec::new(),
+                        named: Vec::new(),
+                    },
                     body: Some(FuncBody {
                         modifiers: FuncBodyModifierSet::from_iter([FuncBodyModifier::Async]),
                         content: FuncBodyContent::Expr("\"abc\"")

--- a/dart-parser/src/parser/scope.rs
+++ b/dart-parser/src/parser/scope.rs
@@ -3,6 +3,7 @@ use nom::{
     bytes::complete::is_not,
     character::complete::char,
     combinator::{cut, recognize},
+    error::context,
     sequence::{preceded, terminated},
 };
 
@@ -22,11 +23,14 @@ pub fn block(s: &str) -> PResult<&str> {
 
 /// Note that this parser strips the outermost brackets.
 fn scope<'s>(open: char, close: char) -> impl FnMut(&'s str) -> PResult<&'s str> {
-    preceded(
-        char(open),
-        cut(terminated(
-            recognize(skip_many0(alt((is_not(SCOPE_STOP_CHARS), any_scope)))),
-            char(close),
-        )),
+    context(
+        "scope",
+        preceded(
+            char(open),
+            cut(terminated(
+                recognize(skip_many0(alt((is_not(SCOPE_STOP_CHARS), any_scope)))),
+                char(close),
+            )),
+        ),
     )
 }

--- a/dart-parser/src/parser/string.rs
+++ b/dart-parser/src/parser/string.rs
@@ -2,6 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::{is_not, tag},
     combinator::{cut, recognize},
+    error::context,
     multi::many0_count,
     sequence::{preceded, terminated},
 };
@@ -33,7 +34,7 @@ pub fn string_simple(s: &str) -> PResult<&str> {
         )),
     );
 
-    alt((dq, sq))(s)
+    context("string_simple", alt((dq, sq)))(s)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
+ Parse positional function parameters
+ Do not parse reserved words as identifiers
+ Use `nom::error::context()` here and there