### PR TITLE
Parse enum "headers"

### DIFF
--- a/.github/workflows/validation.yaml
+++ b/.github/workflows/validation.yaml
@@ -17,8 +17,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Build
-        run: cargo build --verbose
+        run: cargo build
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test
       - name: Run Clippy
         run: cargo clippy -- --deny warnings

--- a/dart-parser/src/dart.rs
+++ b/dart-parser/src/dart.rs
@@ -1,21 +1,26 @@
-mod class;
-pub mod directive;
-mod func;
-mod var;
+pub mod class;
 pub mod comment;
+pub mod directive;
+pub mod enum_ty;
+pub mod func;
+pub mod var;
 
-pub use class::*;
-pub use func::*;
-pub use var::*;
+pub use class::Class;
+pub use comment::Comment;
+pub use directive::Directive;
+pub use enum_ty::EnumTy;
+pub use func::Func;
+pub use var::Var;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Dart<'s> {
     Verbatim(&'s str),
-    Directive(directive::Directive<'s>),
+    Comment(Comment<'s>),
+    Directive(Directive<'s>),
     Var(Var<'s>),
     Func(Func<'s>),
-    Comment(comment::Comment<'s>),
     Class(Class<'s>),
+    Enum(EnumTy<'s>),
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/dart-parser/src/dart/enum_ty.rs
+++ b/dart-parser/src/dart/enum_ty.rs
@@ -1,0 +1,7 @@
+use super::IdentifierExt;
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct EnumTy<'s> {
+    pub name: &'s str,
+    pub implements: Vec<IdentifierExt<'s>>,
+}

--- a/dart-parser/src/parser.rs
+++ b/dart-parser/src/parser.rs
@@ -2,6 +2,7 @@ mod class;
 mod comment;
 mod common;
 mod directive;
+mod enum_ty;
 mod expr;
 mod func;
 mod scope;
@@ -21,7 +22,9 @@ use nom::{
 
 use crate::{dart::*, parser::class::class};
 
-use self::{comment::comment, common::spbr, directive::directive, func::func, var::var};
+use self::{
+    comment::comment, common::spbr, directive::directive, enum_ty::enum_ty, func::func, var::var,
+};
 
 type PResult<'s, T, E> = Result<(&'s str, T), nom::Err<E>>;
 
@@ -37,6 +40,7 @@ where
             var.map(Dart::Var),
             func.map(Dart::Func),
             class.map(Dart::Class),
+            enum_ty.map(Dart::Enum),
         ))),
         eof,
     )(s)
@@ -48,8 +52,14 @@ mod tests {
     use nom::error::VerboseError;
 
     use crate::dart::{
+        class::{ClassModifier, ClassModifierSet},
         comment::Comment,
         directive::{Directive, Import},
+        func::{
+            FuncBody, FuncBodyContent, FuncBodyModifierSet, FuncModifierSet, FuncParam,
+            FuncParamModifierSet, FuncParams,
+        },
+        var::{VarModifier, VarModifierSet},
     };
 
     use super::*;

--- a/dart-parser/src/parser/class.rs
+++ b/dart-parser/src/parser/class.rs
@@ -7,7 +7,10 @@ use nom::{
     sequence::{pair, preceded, terminated, tuple},
 };
 
-use crate::dart::{Class, ClassModifier, ClassModifierSet, IdentifierExt};
+use crate::dart::{
+    class::{ClassModifier, ClassModifierSet},
+    Class, IdentifierExt,
+};
 
 use super::{common::*, scope::block, PResult};
 
@@ -69,7 +72,7 @@ where
     )(s)
 }
 
-fn implements_clause<'s, E>(s: &'s str) -> PResult<Vec<IdentifierExt>, E>
+pub fn implements_clause<'s, E>(s: &'s str) -> PResult<Vec<IdentifierExt>, E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
 {

--- a/dart-parser/src/parser/common.rs
+++ b/dart-parser/src/parser/common.rs
@@ -51,6 +51,8 @@ where
 
     fn is_part_char(c: char) -> bool {
         is_start_char(c) || c.is_ascii_digit()
+        // Parse composite identifiers as a single identifier
+        || c == '.'
     }
 
     context("identifier", |s| {

--- a/dart-parser/src/parser/enum_ty.rs
+++ b/dart-parser/src/parser/enum_ty.rs
@@ -1,0 +1,72 @@
+use nom::{
+    bytes::complete::tag,
+    combinator::opt,
+    error::{context, ContextError, ParseError},
+    sequence::{pair, preceded, terminated, tuple},
+    Parser,
+};
+
+use crate::dart::EnumTy;
+
+use super::{
+    class::implements_clause,
+    common::{identifier, spbr},
+    scope::block,
+    PResult,
+};
+
+pub fn enum_ty<'s, E>(s: &'s str) -> PResult<EnumTy, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "enum_ty",
+        tuple((
+            terminated(preceded(pair(tag("enum"), spbr), identifier), opt(spbr)),
+            opt(terminated(implements_clause, opt(spbr))),
+            block,
+        )),
+    )
+    .map(|(name, implements, _)| EnumTy {
+        name,
+        implements: implements.unwrap_or(Vec::new()),
+    })
+    .parse(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::error::VerboseError;
+
+    use crate::dart::IdentifierExt;
+
+    use super::*;
+
+    #[test]
+    fn enum_test() {
+        assert_eq!(
+            enum_ty::<VerboseError<_>>("enum Angle { thirtyDegrees }x"),
+            Ok((
+                "x",
+                EnumTy {
+                    name: "Angle",
+                    implements: Vec::new()
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn enum_implements_test() {
+        assert_eq!(
+            enum_ty::<VerboseError<_>>("enum Angle implements Serializable { thirtyDegrees }x"),
+            Ok((
+                "x",
+                EnumTy {
+                    name: "Angle",
+                    implements: vec![IdentifierExt::name("Serializable")]
+                }
+            ))
+        );
+    }
+}

--- a/dart-parser/src/parser/var.rs
+++ b/dart-parser/src/parser/var.rs
@@ -8,7 +8,10 @@ use nom::{
     Parser,
 };
 
-use crate::dart::{Var, VarModifier, VarModifierSet};
+use crate::dart::{
+    var::{VarModifier, VarModifierSet},
+    Var,
+};
 
 use super::{
     common::{identifier, identifier_ext, spbr},

--- a/reptr/src/main.rs
+++ b/reptr/src/main.rs
@@ -1,9 +1,8 @@
+use read_dir_ext::ReadDirExt;
 use std::{env, fs, io, path::Path};
 
 mod error_context;
 mod read_dir_ext;
-
-use read_dir_ext::ReadDirExt;
 
 use crate::error_context::ErrorContext;
 
@@ -11,7 +10,7 @@ fn main() -> io::Result<()> {
     let cwd = env::current_dir()?;
 
     let read_dir_ext = ReadDirExt::new(
-        cwd,
+        cwd.clone(),
         |context, path| {
             let dir_name = path.file_name().and_then(|s| s.to_str());
             let context = if dir_name.is_some_and(|s| s.starts_with('.')) {
@@ -51,15 +50,18 @@ fn main() -> io::Result<()> {
                 total_count += 1;
                 let result = try_load_parse(&path);
                 // let result = try_mmap_parse(&path);
+
+                let rel_path = path.strip_prefix(&cwd).unwrap();
+
                 match result {
                     Ok(_) => {
                         success_count += 1;
-                        // println!("[Success] [{context}] {path:?}");
-                        print!("*");
+                        // println!("[PARSED] [{context}] {rel_path:?}");
+                        println!("[PARSED] {rel_path:?}");
                     }
-                    Err(_) => {
-                        // println!("[Failure] [{context}] {path:?}");
-                        print!(" ");
+                    Err(e) => {
+                        // println!("[PARSED] [{context}] {rel_path:?}");
+                        println!("[FAILED] {rel_path:?}\n{e}");
                     }
                 }
             }


### PR DESCRIPTION
+ Parse enum "headers"
+ Parse composite identifiers as a single identifier (e.g. `p.join`)
+ Fix/improve the import directive parser