### PR TITLE
Delete `Dart::Verbatim`

### DIFF
--- a/dart-parser/src/dart.rs
+++ b/dart-parser/src/dart.rs
@@ -14,7 +14,6 @@ pub use var::Var;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Dart<'s> {
-    Verbatim(&'s str),
     Comment(Comment<'s>),
     Directive(Directive<'s>),
     Var(Var<'s>),


### PR DESCRIPTION
`Dart::Verbatim` only adds unneeded verbosity at the moment. When (and if) implementing [accurate back-to-source transformation](https://github.com/werediver/dart-reptr-rs/issues/7), it can be relatively easily re-introduced.