### PR TITLE
Parse annotations, function calls, type parameters

### DIFF
--- a/dart-parser/src/dart.rs
+++ b/dart-parser/src/dart.rs
@@ -1,23 +1,32 @@
+pub mod annotation;
 pub mod class;
 pub mod comment;
 pub mod directive;
 pub mod enum_ty;
+pub mod expr;
 pub mod func;
+pub mod func_call;
 pub mod identifier_ext;
+pub mod type_param;
 pub mod var;
 
+pub use annotation::Annotation;
 pub use class::Class;
 pub use comment::Comment;
 pub use directive::Directive;
 pub use enum_ty::EnumTy;
+pub use expr::Expr;
 pub use func::Func;
+pub use func_call::FuncCall;
 pub use identifier_ext::IdentifierExt;
+pub use type_param::TypeParam;
 pub use var::Var;
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Dart<'s> {
     Comment(Comment<'s>),
     Directive(Directive<'s>),
+    Annotation(Annotation<'s>),
     Var(Var<'s>),
     Func(Func<'s>),
     Class(Class<'s>),

--- a/dart-parser/src/dart/annotation.rs
+++ b/dart-parser/src/dart/annotation.rs
@@ -1,0 +1,7 @@
+use super::FuncCall;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum Annotation<'s> {
+    Ident(&'s str),
+    FuncCall(FuncCall<'s>),
+}

--- a/dart-parser/src/dart/class.rs
+++ b/dart-parser/src/dart/class.rs
@@ -2,13 +2,14 @@ use tiny_set::with_tiny_set;
 
 use super::{
     func::{FuncBodyContent, FuncParams},
-    Comment, Func, IdentifierExt, Var,
+    Annotation, Comment, Func, IdentifierExt, TypeParam, Var,
 };
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Class<'s> {
     pub modifiers: ClassModifierSet,
     pub name: &'s str,
+    pub type_params: Vec<TypeParam<'s>>,
     pub extends: Option<IdentifierExt<'s>>,
     pub implements: Vec<IdentifierExt<'s>>,
     pub body: Vec<ClassMember<'s>>,
@@ -38,6 +39,7 @@ pub enum ClassModifier {
 #[derive(PartialEq, Eq, Debug)]
 pub enum ClassMember<'s> {
     Comment(Comment<'s>),
+    Annotation(Annotation<'s>),
     Constructor(Constructor<'s>),
     Var(Var<'s>),
     Func(Func<'s>),

--- a/dart-parser/src/dart/expr.rs
+++ b/dart-parser/src/dart/expr.rs
@@ -1,0 +1,25 @@
+#[derive(Debug)]
+pub enum Expr<'s> {
+    Verbatim(&'s str),
+    Ident(&'s str),
+    String(&'s str),
+}
+
+impl<'s> PartialEq for Expr<'s> {
+    fn eq(&self, other: &Self) -> bool {
+        use Expr::*;
+
+        match (self, other) {
+            (Verbatim(a), Verbatim(b)) => a == b,
+            (Verbatim(_), _) => false,
+
+            (Ident(a), Ident(b)) => a == b,
+            (Ident(_), _) => false,
+
+            (String(a), String(b)) => a == b,
+            (String(_), _) => false,
+        }
+    }
+}
+
+impl<'s> Eq for Expr<'s> {}

--- a/dart-parser/src/dart/func.rs
+++ b/dart-parser/src/dart/func.rs
@@ -1,13 +1,13 @@
 use tiny_set::with_tiny_set;
 
-use super::IdentifierExt;
+use super::{Expr, IdentifierExt, TypeParam};
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Func<'s> {
     pub modifiers: FuncModifierSet,
     pub return_type: IdentifierExt<'s>,
     pub name: &'s str,
-    // pub type_params: Vec<_>,
+    pub type_params: Vec<TypeParam<'s>>,
     pub params: FuncParams<'s>,
     pub body: Option<FuncBody<'s>>,
 }
@@ -32,7 +32,7 @@ pub struct FuncParam<'s> {
     pub modifiers: FuncParamModifierSet,
     pub param_type: Option<IdentifierExt<'s>>,
     pub name: &'s str,
-    pub initializer: Option<&'s str>,
+    pub initializer: Option<Expr<'s>>,
 }
 
 #[with_tiny_set]
@@ -61,5 +61,5 @@ pub enum FuncBodyModifier {
 pub enum FuncBodyContent<'s> {
     Block(&'s str),
     /// Not allowed in generator functions and constructors, except factory constructors.
-    Expr(&'s str),
+    Expr(Expr<'s>),
 }

--- a/dart-parser/src/dart/func_call.rs
+++ b/dart-parser/src/dart/func_call.rs
@@ -1,0 +1,13 @@
+use super::{Expr, IdentifierExt};
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct FuncCall<'s> {
+    pub ident: IdentifierExt<'s>,
+    pub args: Vec<FuncArg<'s>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct FuncArg<'s> {
+    pub name: Option<&'s str>,
+    pub value: Expr<'s>,
+}

--- a/dart-parser/src/dart/type_param.rs
+++ b/dart-parser/src/dart/type_param.rs
@@ -1,0 +1,7 @@
+use super::IdentifierExt;
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct TypeParam<'s> {
+    pub name: &'s str,
+    pub extends: Option<IdentifierExt<'s>>,
+}

--- a/dart-parser/src/dart/var.rs
+++ b/dart-parser/src/dart/var.rs
@@ -1,13 +1,13 @@
 use tiny_set::with_tiny_set;
 
-use super::IdentifierExt;
+use super::{Expr, IdentifierExt};
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct Var<'s> {
     pub modifiers: VarModifierSet,
     pub var_type: Option<IdentifierExt<'s>>,
     pub name: &'s str,
-    pub initializer: Option<&'s str>,
+    pub initializer: Option<Expr<'s>>,
 }
 
 #[with_tiny_set]

--- a/dart-parser/src/parser/annotation.rs
+++ b/dart-parser/src/parser/annotation.rs
@@ -1,0 +1,89 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    combinator::cut,
+    error::{ContextError, ParseError},
+    sequence::preceded,
+    Parser,
+};
+
+use crate::dart::Annotation;
+
+use super::{func_call::func_call, identifier::identifier, PResult};
+
+pub fn annotation<'s, E>(s: &'s str) -> PResult<Annotation, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    preceded(
+        tag("@"),
+        cut(alt((
+            func_call.map(Annotation::FuncCall),
+            identifier.map(Annotation::Ident),
+        ))),
+    )(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::error::VerboseError;
+
+    use crate::dart::{func_call::FuncArg, Expr, FuncCall, IdentifierExt};
+
+    use super::*;
+
+    #[test]
+    fn annotation_const_test() {
+        assert_eq!(
+            annotation::<VerboseError<_>>("@immutable\nx"),
+            Ok(("\nx", Annotation::Ident("immutable")))
+        );
+    }
+
+    #[test]
+    fn annotation_constructor_test() {
+        assert_eq!(
+            annotation::<VerboseError<_>>("@JsonSerializable()\nx"),
+            Ok((
+                "\nx",
+                Annotation::FuncCall(FuncCall {
+                    ident: IdentifierExt::name("JsonSerializable"),
+                    args: Vec::new(),
+                })
+            ))
+        );
+    }
+
+    #[test]
+    fn annotation_constructor_args_test() {
+        assert_eq!(
+            annotation::<VerboseError<_>>(
+                "@JsonSerializable(1, 2.0, named: 'three', expr: 1 + 2)\nx"
+            ),
+            Ok((
+                "\nx",
+                Annotation::FuncCall(FuncCall {
+                    ident: IdentifierExt::name("JsonSerializable"),
+                    args: vec![
+                        FuncArg {
+                            name: None,
+                            value: Expr::Verbatim("1"),
+                        },
+                        FuncArg {
+                            name: None,
+                            value: Expr::Verbatim("2.0"),
+                        },
+                        FuncArg {
+                            name: Some("named"),
+                            value: Expr::String("three"),
+                        },
+                        FuncArg {
+                            name: Some("expr"),
+                            value: Expr::Verbatim("1 + 2"),
+                        }
+                    ],
+                }),
+            ))
+        );
+    }
+}

--- a/dart-parser/src/parser/common.rs
+++ b/dart-parser/src/parser/common.rs
@@ -2,7 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::{is_a, tag},
     error::ParseError,
-    multi::fold_many0,
+    multi::{fold_many0, fold_many1},
     InputLength, Parser,
 };
 
@@ -15,6 +15,15 @@ where
     E: ParseError<I>,
 {
     fold_many0(p, || {}, |_, _| {})
+}
+
+pub fn skip_many1<P, I, O, E>(p: P) -> impl Parser<I, (), E>
+where
+    P: Parser<I, O, E>,
+    I: Clone + InputLength,
+    E: ParseError<I>,
+{
+    fold_many1(p, || {}, |_, _| {})
 }
 
 /// Parse one or more whitespace characters, including line breaks.

--- a/dart-parser/src/parser/expr.rs
+++ b/dart-parser/src/parser/expr.rs
@@ -1,26 +1,42 @@
 use nom::{
     branch::alt,
     bytes::complete::is_not,
-    combinator::recognize,
+    combinator::{eof, opt, recognize},
     error::{ContextError, ParseError},
+    sequence::{preceded, terminated},
+    Parser,
 };
 
-use crate::parser::{
-    common::skip_many0,
-    scope::{any_scope, SCOPE_STOP_CHARS},
+use crate::{
+    dart::Expr,
+    parser::{
+        common::{skip_many1, spbr},
+        scope::{any_scope, SCOPE_STOP_CHARS},
+    },
 };
 
-use super::PResult;
+use super::{identifier::identifier, string::string_simple, PResult};
 
-/// This is a pretty shady expression parser.
-pub fn expr<'s, E>(s: &'s str) -> PResult<&str, E>
+pub fn expr<'s, E>(s: &'s str) -> PResult<Expr, E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
 {
     const EXPR_STOP_CHARS_EXT: &str = "()[]{},;";
     debug_assert!(EXPR_STOP_CHARS_EXT.starts_with(SCOPE_STOP_CHARS));
 
-    recognize(skip_many0(alt((is_not(EXPR_STOP_CHARS_EXT), any_scope))))(s)
+    recognize(
+        // Make sure something other than whitespace is consumed
+        preceded(
+            opt(spbr),
+            skip_many1(alt((is_not(EXPR_STOP_CHARS_EXT), any_scope))),
+        ),
+    )
+    .and_then(alt((
+        terminated(identifier, eof).map(Expr::Ident),
+        terminated(string_simple, eof).map(Expr::String),
+        |s: &'s str| Ok((&s[s.len()..], Expr::Verbatim(s))),
+    )))
+    .parse(s)
 }
 
 #[cfg(test)]
@@ -32,16 +48,16 @@ mod tests {
     #[test]
     fn expr_string_test() {
         assert_eq!(
-            expr::<VerboseError<_>>("\"text\"; "),
-            Ok(("; ", "\"text\""))
+            expr::<VerboseError<_>>("'text'; "),
+            Ok(("; ", Expr::String("text")))
         );
     }
 
     #[test]
     fn expr_test() {
         assert_eq!(
-            expr::<VerboseError<_>>("f(\"text\", (a) => null) + 1; "),
-            Ok(("; ", "f(\"text\", (a) => null) + 1"))
+            expr::<VerboseError<_>>("f('text', (a) => null) + 1; "),
+            Ok(("; ", Expr::Verbatim("f('text', (a) => null) + 1")))
         );
     }
 }

--- a/dart-parser/src/parser/func_call.rs
+++ b/dart-parser/src/parser/func_call.rs
@@ -1,0 +1,116 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    combinator::{cut, opt},
+    error::{context, ContextError, ParseError},
+    multi::separated_list0,
+    sequence::{pair, preceded, terminated, tuple},
+    Parser,
+};
+
+use crate::dart::func_call::{FuncArg, FuncCall};
+
+use super::{
+    common::spbr,
+    expr::expr,
+    identifier::{identifier, identifier_ext},
+    PResult,
+};
+
+pub fn func_call<'s, E>(s: &'s str) -> PResult<FuncCall, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "func_call",
+        pair(terminated(identifier_ext, opt(spbr)), func_args)
+            .map(|(ident, args)| FuncCall { ident, args }),
+    )(s)
+}
+
+pub fn func_args<'s, E>(s: &'s str) -> PResult<Vec<FuncArg>, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "func_args",
+        preceded(
+            pair(tag("("), opt(spbr)),
+            cut(terminated(
+                separated_list0(pair(tag(","), opt(spbr)), terminated(func_arg, opt(spbr))),
+                tag(")"),
+            )),
+        ),
+    )(s)
+}
+
+pub fn func_arg<'s, E>(s: &'s str) -> PResult<FuncArg, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    alt((
+        pair(
+            terminated(identifier, tuple((opt(spbr), tag(":"), opt(spbr)))),
+            expr,
+        )
+        .map(|(name, value)| FuncArg {
+            name: Some(name),
+            value,
+        }),
+        expr.map(|value| FuncArg { name: None, value }),
+    ))(s)
+}
+
+#[cfg(test)]
+mod tests {
+    use nom::error::VerboseError;
+
+    use crate::dart::{func_call::FuncArg, Expr, IdentifierExt};
+
+    use super::*;
+
+    #[test]
+    fn func_call_simple_test() {
+        assert_eq!(
+            func_call::<VerboseError<_>>("f() x"),
+            Ok((
+                " x",
+                FuncCall {
+                    ident: IdentifierExt::name("f"),
+                    args: Vec::new(),
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn func_call_mixed_test() {
+        assert_eq!(
+            func_call::<VerboseError<_>>("f<int>(1, named: two, verbatim: 1 + 2) x"),
+            Ok((
+                " x",
+                FuncCall {
+                    ident: IdentifierExt {
+                        name: "f",
+                        type_args: vec![IdentifierExt::name("int")],
+                        is_nullable: false
+                    },
+                    args: vec![
+                        FuncArg {
+                            name: None,
+                            value: Expr::Verbatim("1")
+                        },
+                        FuncArg {
+                            name: Some("named"),
+                            value: Expr::Ident("two")
+                        },
+                        FuncArg {
+                            name: Some("verbatim"),
+                            value: Expr::Verbatim("1 + 2")
+                        },
+                    ]
+                }
+            ))
+        );
+    }
+}

--- a/dart-parser/src/parser/identifier.rs
+++ b/dart-parser/src/parser/identifier.rs
@@ -49,7 +49,7 @@ where
     })(s)
 }
 
-/// Parse an identifier with type arguments and the nullability indicator (e.g. `Future<int>?`).
+/// Parse an identifier with type arguments and the nullability indicator (e.g. `x`, `Future<int>?`).
 pub fn identifier_ext<'s, E>(s: &'s str) -> PResult<IdentifierExt, E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
@@ -58,13 +58,7 @@ where
         "identifier_ext",
         tuple((
             identifier,
-            opt(preceded(
-                tuple((opt(spbr), tag("<"), opt(spbr))),
-                cut(terminated(
-                    separated_list1(tuple((opt(spbr), tag(","), opt(spbr))), identifier_ext),
-                    pair(opt(spbr), tag(">")),
-                )),
-            )),
+            opt(preceded(opt(spbr), type_args)),
             opt(preceded(opt(spbr), tag("?"))),
         ))
         .map(|(name, args, nullability_ind)| IdentifierExt {
@@ -74,6 +68,22 @@ where
         }),
     )
     .parse(s)
+}
+
+fn type_args<'s, E>(s: &'s str) -> PResult<Vec<IdentifierExt>, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "type_args",
+        preceded(
+            pair(tag("<"), opt(spbr)),
+            cut(terminated(
+                separated_list1(tuple((opt(spbr), tag(","), opt(spbr))), identifier_ext),
+                pair(opt(spbr), tag(">")),
+            )),
+        ),
+    )(s)
 }
 
 #[cfg(test)]

--- a/dart-parser/src/parser/string.rs
+++ b/dart-parser/src/parser/string.rs
@@ -3,11 +3,10 @@ use nom::{
     bytes::complete::{is_not, tag},
     combinator::{cut, recognize},
     error::{context, ContextError, ParseError},
-    multi::many0_count,
     sequence::{preceded, terminated},
 };
 
-use super::PResult;
+use super::{common::skip_many0, PResult};
 
 /// Parse a single- or double-quoted string literal without escape-sequences.
 ///
@@ -25,14 +24,14 @@ where
     let dq = preceded(
         tag("\""),
         cut(terminated(
-            recognize(many0_count(is_not("\\\"\r\n"))),
+            recognize(skip_many0(is_not("\\\"\r\n"))),
             tag("\""),
         )),
     );
     let sq = preceded(
         tag("'"),
         cut(terminated(
-            recognize(many0_count(is_not("\\'\r\n"))),
+            recognize(skip_many0(is_not("\\'\r\n"))),
             tag("'"),
         )),
     );

--- a/dart-parser/src/parser/type_params.rs
+++ b/dart-parser/src/parser/type_params.rs
@@ -1,0 +1,49 @@
+use nom::{
+    bytes::complete::tag,
+    combinator::{cut, opt},
+    error::{context, ContextError, ParseError},
+    multi::separated_list1,
+    sequence::{pair, preceded, terminated, tuple},
+    Parser,
+};
+
+use crate::dart::TypeParam;
+
+use super::{
+    common::spbr,
+    identifier::{identifier, identifier_ext},
+    PResult,
+};
+
+pub fn type_params<'s, E>(s: &'s str) -> PResult<Vec<TypeParam>, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "type_params",
+        preceded(
+            pair(tag("<"), opt(spbr)),
+            cut(terminated(
+                separated_list1(pair(tag(","), opt(spbr)), terminated(type_param, opt(spbr))),
+                tag(">"),
+            )),
+        ),
+    )(s)
+}
+
+pub fn type_param<'s, E>(s: &'s str) -> PResult<TypeParam, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "type_param",
+        pair(
+            identifier,
+            opt(preceded(
+                tuple((spbr, tag("extends"), spbr)),
+                cut(identifier_ext),
+            )),
+        )
+        .map(|(name, extends)| TypeParam { name, extends }),
+    )(s)
+}

--- a/dart-parser/src/parser/var.rs
+++ b/dart-parser/src/parser/var.rs
@@ -85,7 +85,7 @@ fn var_modifier<'s, E: ParseError<&'s str>>(s: &'s str) -> PResult<VarModifier, 
 mod tests {
     use nom::error::VerboseError;
 
-    use crate::dart::IdentifierExt;
+    use crate::dart::{Expr, IdentifierExt};
 
     use super::*;
 
@@ -112,7 +112,7 @@ mod tests {
     #[test]
     fn var_init() {
         assert_eq!(
-            var::<VerboseError<_>>("static const type = \"type\"; "),
+            var::<VerboseError<_>>("static const type = 'type'; "),
             Ok((
                 " ",
                 Var {
@@ -121,7 +121,27 @@ mod tests {
                     ),
                     var_type: None,
                     name: "type",
-                    initializer: Some("\"type\""),
+                    initializer: Some(Expr::String("type")),
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn var_list_init() {
+        assert_eq!(
+            var::<VerboseError<_>>("List<int> xs = []; "),
+            Ok((
+                " ",
+                Var {
+                    modifiers: VarModifierSet::default(),
+                    var_type: Some(IdentifierExt {
+                        name: "List",
+                        type_args: vec![IdentifierExt::name("int")],
+                        is_nullable: false
+                    }),
+                    name: "xs",
+                    initializer: Some(Expr::Verbatim("[]")),
                 }
             ))
         );
@@ -137,7 +157,7 @@ mod tests {
                     modifiers: VarModifierSet::default(),
                     var_type: None,
                     name: "i",
-                    initializer: Some("0"),
+                    initializer: Some(Expr::Verbatim("0")),
                 }
             ))
         );
@@ -153,7 +173,7 @@ mod tests {
                     modifiers: VarModifierSet::default(),
                     var_type: Some(IdentifierExt::name("double")),
                     name: "x",
-                    initializer: Some("0"),
+                    initializer: Some(Expr::Verbatim("0")),
                 }
             ))
         );

--- a/reptr/src/main.rs
+++ b/reptr/src/main.rs
@@ -46,22 +46,20 @@ fn main() -> io::Result<()> {
 
     for entry in read_dir_ext {
         match entry {
-            Ok((_context, path)) => {
+            Ok((context, path)) => {
                 total_count += 1;
                 let result = try_load_parse(&path);
-                // let result = try_mmap_parse(&path);
+                // let result = _try_mmap_parse(&path);
 
                 let rel_path = path.strip_prefix(&cwd).unwrap();
 
                 match result {
                     Ok(_) => {
                         success_count += 1;
-                        // println!("[PARSED] [{context}] {rel_path:?}");
-                        println!("[PARSED] {rel_path:?}");
+                        println!("[PARSED] [{context}] {rel_path:?}");
                     }
                     Err(e) => {
-                        // println!("[PARSED] [{context}] {rel_path:?}");
-                        println!("[FAILED] {rel_path:?}\n{e}");
+                        println!("[FAILED] [{context}] {rel_path:?}\n{e}");
                     }
                 }
             }


### PR DESCRIPTION
+ Parse annotations, function calls, type parameters
+ Rework expression parser to discriminate identifiers and strings
+ Delete `ClassMember::Verbatim`
+ Improve error reporting in `class_body`

Resolves #34
Resolves #40