### PR TITLE
Allow comments and annotations in above enum values

### DIFF
--- a/dart-parser/src/dart/enum_ty.rs
+++ b/dart-parser/src/dart/enum_ty.rs
@@ -1,11 +1,18 @@
-use super::{class::ClassMember, func_call::FuncArg, IdentifierExt};
+use super::{class::ClassMember, func_call::FuncArg, Annotation, Comment, IdentifierExt};
 
 #[derive(PartialEq, Eq, Debug)]
 pub struct EnumTy<'s> {
     pub name: &'s str,
     pub implements: Vec<IdentifierExt<'s>>,
-    pub values: Vec<EnumValue<'s>>,
+    pub values: Vec<EnumMember<'s>>,
     pub members: Vec<ClassMember<'s>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum EnumMember<'s> {
+    Comment(Comment<'s>),
+    Annotation(Annotation<'s>),
+    Value(EnumValue<'s>),
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/dart-parser/src/parser/enum_ty.rs
+++ b/dart-parser/src/parser/enum_ty.rs
@@ -8,10 +8,16 @@ use nom::{
     Parser,
 };
 
-use crate::dart::{class::ClassMember, enum_ty::EnumValue, EnumTy};
+use crate::dart::{
+    class::ClassMember,
+    enum_ty::{EnumMember, EnumValue},
+    EnumTy,
+};
 
 use super::{
+    annotation::annotation,
     class::{class_member, implements_clause},
+    comment::comment,
     common::spbr,
     func_call::func_args,
     identifier::identifier,
@@ -39,7 +45,7 @@ where
     .parse(s)
 }
 
-fn enum_body<'s, E>(s: &'s str) -> PResult<(Vec<EnumValue>, Vec<ClassMember>), E>
+fn enum_body<'s, E>(s: &'s str) -> PResult<(Vec<EnumMember>, Vec<ClassMember>), E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
 {
@@ -52,10 +58,11 @@ where
                     terminated(
                         separated_list0(
                             pair(tag(","), opt(spbr)),
-                            terminated(enum_value, opt(spbr)),
+                            terminated(enum_value_ext, opt(spbr)),
                         ),
                         opt(pair(tag(","), opt(spbr))),
-                    ),
+                    )
+                    .map(|items| items.into_iter().flatten().collect::<Vec<_>>()),
                     alt((
                         preceded(
                             pair(tag(";"), opt(spbr)),
@@ -67,6 +74,28 @@ where
                 tag("}"),
             )),
         ),
+    )(s)
+}
+
+fn enum_value_ext<'s, E>(s: &'s str) -> PResult<Vec<EnumMember>, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context(
+        "enum_value_ext",
+        pair(
+            many0(alt((
+                terminated(comment, opt(spbr)).map(EnumMember::Comment),
+                terminated(annotation, opt(spbr)).map(EnumMember::Annotation),
+            ))),
+            enum_value,
+        )
+        .map(|(meta, value)| {
+            let mut value_ext = meta;
+            value_ext.push(EnumMember::Value(value));
+
+            value_ext
+        }),
     )(s)
 }
 
@@ -91,7 +120,7 @@ where
 mod tests {
     use nom::error::VerboseError;
 
-    use crate::dart::{func_like::FuncParams, IdentifierExt};
+    use crate::dart::{Annotation, Comment, FuncCall, IdentifierExt};
 
     use super::*;
 
@@ -104,10 +133,38 @@ mod tests {
                 EnumTy {
                     name: "AnyAngle",
                     implements: Vec::new(),
-                    values: vec![EnumValue {
+                    values: vec![EnumMember::Value(EnumValue {
                         name: "thirtyDegrees",
                         args: Vec::new(),
-                    }],
+                    })],
+                    members: Vec::new(),
+                }
+            ))
+        );
+    }
+
+    #[test]
+    fn enum_ext_test() {
+        assert_eq!(
+            enum_ty::<VerboseError<_>>(
+                "enum AnyAngle {\n  // Here it comes. Big...\n  @Badaboom()\n  thirtyDegrees\n}x"
+            ),
+            Ok((
+                "x",
+                EnumTy {
+                    name: "AnyAngle",
+                    implements: Vec::new(),
+                    values: vec![
+                        EnumMember::Comment(Comment::SingleLine("// Here it comes. Big...\n")),
+                        EnumMember::Annotation(Annotation::FuncCall(FuncCall {
+                            ident: IdentifierExt::name("Badaboom"),
+                            args: Vec::new()
+                        })),
+                        EnumMember::Value(EnumValue {
+                            name: "thirtyDegrees",
+                            args: Vec::new(),
+                        })
+                    ],
                     members: Vec::new(),
                 }
             ))
@@ -123,10 +180,10 @@ mod tests {
                 EnumTy {
                     name: "AnyAngle",
                     implements: vec![IdentifierExt::name("Serializable")],
-                    values: vec![EnumValue {
+                    values: vec![EnumMember::Value(EnumValue {
                         name: "thirtyDegrees",
                         args: Vec::new(),
-                    }],
+                    })],
                     members: Vec::new(),
                 }
             ))


### PR DESCRIPTION
The new implementation does not allow comments below the last enum value, which is allowed in Dart and may realistically appear in the wild, e.g.

```dart
enum Abc {
  a,
  b,
  // c,
}
```