### PR TITLE
Small(-ish) improvements

### DIFF
--- a/dart-parser/src/dart/maybe_required.rs
+++ b/dart-parser/src/dart/maybe_required.rs
@@ -1,4 +1,3 @@
-use core::ops::Deref;
 use std::fmt::Debug;
 
 pub struct MaybeRequired<T> {
@@ -26,10 +25,8 @@ impl<T> MaybeRequired<T> {
     }
 }
 
-impl<T> Deref for MaybeRequired<T> {
-    type Target = T;
-
-    fn deref(&self) -> &T {
+impl<T> AsRef<T> for MaybeRequired<T> {
+    fn as_ref(&self) -> &T {
         &self.value
     }
 }

--- a/dart-parser/src/dart/ty.rs
+++ b/dart-parser/src/dart/ty.rs
@@ -1,4 +1,4 @@
-use super::func_like::FuncParams;
+use super::{func_like::FuncParams, TypeParam};
 
 #[derive(PartialEq, Eq, Debug)]
 pub enum Type<'s> {
@@ -15,7 +15,7 @@ impl<'s> Type<'s> {
 #[derive(PartialEq, Eq, Debug)]
 pub struct NotFuncType<'s> {
     pub name: &'s str,
-    pub type_args: Vec<NotFuncType<'s>>,
+    pub type_args: Vec<Type<'s>>,
     pub is_nullable: bool,
 }
 
@@ -24,6 +24,14 @@ impl<'s> NotFuncType<'s> {
         Self {
             name,
             type_args: Vec::default(),
+            is_nullable: false,
+        }
+    }
+
+    pub fn void() -> Self {
+        Self {
+            name: "void",
+            type_args: Vec::new(),
             is_nullable: false,
         }
     }
@@ -40,6 +48,7 @@ impl<'s> NotFuncType<'s> {
 #[derive(PartialEq, Eq, Debug)]
 pub struct FuncType<'s> {
     pub return_type: Type<'s>,
+    pub type_params: Vec<TypeParam<'s>>,
     pub params: FuncParams<FuncTypeParam<'s>>,
     pub is_nullable: bool,
 }

--- a/dart-parser/src/parser.rs
+++ b/dart-parser/src/parser.rs
@@ -151,16 +151,16 @@ mod tests {
                             NotFuncType {
                                 name: "A",
                                 type_args: vec![
-                                    NotFuncType {
+                                    Type::NotFunc(NotFuncType {
                                         name: "Future",
-                                        type_args: vec![NotFuncType::name("void")],
+                                        type_args: vec![Type::NotFunc(NotFuncType::name("void"))],
                                         is_nullable: false,
-                                    },
-                                    NotFuncType {
+                                    }),
+                                    Type::NotFunc(NotFuncType {
                                         name: "B",
                                         type_args: Vec::default(),
                                         is_nullable: true,
-                                    },
+                                    }),
                                 ],
                                 is_nullable: false,
                             },
@@ -178,12 +178,12 @@ mod tests {
                         return_type: Type::NotFunc(NotFuncType {
                             name: "Map",
                             type_args: vec![
-                                NotFuncType::name("String"),
-                                NotFuncType {
+                                Type::NotFunc(NotFuncType::name("String")),
+                                Type::NotFunc(NotFuncType {
                                     name: "Object",
                                     type_args: Vec::new(),
                                     is_nullable: true,
-                                }
+                                })
                             ],
                             is_nullable: false,
                         }),

--- a/dart-parser/src/parser/annotation.rs
+++ b/dart-parser/src/parser/annotation.rs
@@ -2,7 +2,7 @@ use nom::{
     branch::alt,
     bytes::complete::tag,
     combinator::cut,
-    error::{ContextError, ParseError},
+    error::{context, ContextError, ParseError},
     sequence::preceded,
     Parser,
 };
@@ -15,12 +15,15 @@ pub fn annotation<'s, E>(s: &'s str) -> PResult<Annotation, E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
 {
-    preceded(
-        tag("@"),
-        cut(alt((
-            func_call.map(Annotation::FuncCall),
-            identifier.map(Annotation::Ident),
-        ))),
+    context(
+        "annotation",
+        preceded(
+            tag("@"),
+            cut(alt((
+                func_call.map(Annotation::FuncCall),
+                identifier.map(Annotation::Ident),
+            ))),
+        ),
     )(s)
 }
 

--- a/dart-parser/src/parser/class.rs
+++ b/dart-parser/src/parser/class.rs
@@ -226,7 +226,7 @@ mod tests {
                     NotFuncType::name("Salt"),
                     NotFuncType {
                         name: "Pepper",
-                        type_args: vec![NotFuncType::name("Black")],
+                        type_args: vec![Type::NotFunc(NotFuncType::name("Black"))],
                         is_nullable: false,
                     }
                 ]
@@ -318,17 +318,17 @@ mod tests {
                     type_params: Vec::new(),
                     extends: Some(NotFuncType {
                         name: "Base",
-                        type_args: vec![NotFuncType::name("T")],
+                        type_args: vec![Type::NotFunc(NotFuncType::name("T"))],
                         is_nullable: false,
                     }),
                     with: Vec::new(),
                     implements: vec![NotFuncType {
                         name: "A",
-                        type_args: vec![NotFuncType {
+                        type_args: vec![Type::NotFunc(NotFuncType {
                             name: "Future",
-                            type_args: vec![NotFuncType::name("void")],
+                            type_args: vec![Type::NotFunc(NotFuncType::name("void"))],
                             is_nullable: false,
-                        }],
+                        })],
                         is_nullable: false,
                     }],
                     body: Vec::new(),

--- a/dart-parser/src/parser/func_call.rs
+++ b/dart-parser/src/parser/func_call.rs
@@ -3,7 +3,6 @@ use nom::{
     bytes::complete::tag,
     combinator::{cut, opt},
     error::{context, ContextError, ParseError},
-    multi::separated_list0,
     sequence::{pair, preceded, terminated, tuple},
     Parser,
 };
@@ -11,7 +10,7 @@ use nom::{
 use crate::dart::func_call::{FuncArg, FuncCall};
 
 use super::{
-    common::spbr,
+    common::{sep_list, spbr, SepMode},
     expr::expr,
     ty::{identifier, not_func_type},
     PResult,
@@ -37,7 +36,12 @@ where
         preceded(
             pair(tag("("), opt(spbr)),
             cut(terminated(
-                separated_list0(pair(tag(","), opt(spbr)), terminated(func_arg, opt(spbr))),
+                sep_list(
+                    0,
+                    SepMode::AllowTrailing,
+                    pair(tag(","), opt(spbr)),
+                    terminated(func_arg, opt(spbr)),
+                ),
                 tag(")"),
             )),
         ),
@@ -65,7 +69,7 @@ where
 mod tests {
     use nom::error::VerboseError;
 
-    use crate::dart::{func_call::FuncArg, Expr, NotFuncType};
+    use crate::dart::{func_call::FuncArg, ty::Type, Expr, NotFuncType};
 
     use super::*;
 
@@ -92,7 +96,7 @@ mod tests {
                 FuncCall {
                     ident: NotFuncType {
                         name: "f",
-                        type_args: vec![NotFuncType::name("int")],
+                        type_args: vec![Type::NotFunc(NotFuncType::name("int"))],
                         is_nullable: false
                     },
                     args: vec![

--- a/dart-parser/src/parser/var.rs
+++ b/dart-parser/src/parser/var.rs
@@ -137,7 +137,7 @@ mod tests {
                     modifiers: VarModifierSet::default(),
                     var_type: Some(Type::NotFunc(NotFuncType {
                         name: "List",
-                        type_args: vec![NotFuncType::name("int")],
+                        type_args: vec![Type::NotFunc(NotFuncType::name("int"))],
                         is_nullable: false
                     })),
                     name: "xs",


### PR DESCRIPTION
+ Parse string interpolation expressions
+ Fix parsing unnamed extensions
+ Parse generic function types
+ Allow function types as type arguments
+ Allow trailing comma in function arguments
+ Use `AsRef` instead of `Deref` for `MaybeRequired`