### PR TITLE
Parse tuples and more

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+resolver = "2"
 members = [
   "reptr",
   "dart-parser",

--- a/dart-parser/src/dart/class.rs
+++ b/dart-parser/src/dart/class.rs
@@ -16,6 +16,8 @@ pub struct Class<'s> {
     pub with: Vec<NotFuncType<'s>>,
     /// Interfaces.
     pub implements: Vec<NotFuncType<'s>>,
+    /// Types a mix-in can be added to.
+    pub mixin_on: Vec<NotFuncType<'s>>,
     pub body: Vec<WithMeta<'s, ClassMember<'s>>>,
 }
 

--- a/dart-parser/src/dart/ty.rs
+++ b/dart-parser/src/dart/ty.rs
@@ -4,7 +4,7 @@ use super::{func_like::FuncParams, TypeParam};
 pub enum Type<'s> {
     NotFunc(NotFuncType<'s>),
     Func(Box<FuncType<'s>>),
-    Tuple(Vec<Type<'s>>),
+    Tuple(Tuple<'s>),
 }
 
 impl<'s> Type<'s> {
@@ -66,4 +66,13 @@ pub struct FuncTypeParamPos<'s> {
 pub struct FuncTypeParamNamed<'s> {
     pub param_type: Type<'s>,
     pub name: &'s str,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct Tuple<'s> {
+    /// A name can be specified for a positional tuple parameter,
+    /// but has no meaning whatsoever.
+    pub params_pos: Vec<FuncTypeParamPos<'s>>,
+    pub params_named: Vec<FuncTypeParamNamed<'s>>,
+    pub is_nullable: bool,
 }

--- a/dart-parser/src/parser.rs
+++ b/dart-parser/src/parser.rs
@@ -8,6 +8,7 @@ mod expr;
 mod extension;
 mod func_call;
 mod func_like;
+mod maybe_required;
 mod meta;
 mod string;
 mod ty;
@@ -137,6 +138,7 @@ mod tests {
                         extends: None,
                         with: Vec::new(),
                         implements: Vec::default(),
+                        mixin_on: Vec::default(),
                         body: vec![
                             WithMeta::value(ClassMember::Constructor(Constructor {
                                 modifier: None,
@@ -192,6 +194,7 @@ mod tests {
                                 },
                                 NotFuncType::name("C")
                             ],
+                            mixin_on: Vec::default(),
                             body: vec![WithMeta::value(ClassMember::Var(Var {
                                 modifiers: VarModifierSet::default(),
                                 var_type: Some(Type::NotFunc(NotFuncType::name("String"))),

--- a/dart-parser/src/parser/annotation.rs
+++ b/dart-parser/src/parser/annotation.rs
@@ -9,7 +9,7 @@ use nom::{
 
 use crate::dart::Annotation;
 
-use super::{func_call::func_call, ty::identifier, PResult};
+use super::{func_call::annotation_func_call, ty::identifier, PResult};
 
 pub fn annotation<'s, E>(s: &'s str) -> PResult<Annotation, E>
 where
@@ -20,7 +20,7 @@ where
         preceded(
             tag("@"),
             cut(alt((
-                func_call.map(Annotation::FuncCall),
+                annotation_func_call.map(Annotation::FuncCall),
                 identifier.map(Annotation::Ident),
             ))),
         ),

--- a/dart-parser/src/parser/enum_ty.rs
+++ b/dart-parser/src/parser/enum_ty.rs
@@ -26,8 +26,8 @@ where
     context(
         "enum_ty",
         tuple((
-            terminated(preceded(pair(tag("enum"), spbr), identifier), opt(spbr)),
-            opt(terminated(implements_clause, opt(spbr))),
+            terminated(preceded(pair(tag("enum"), spbrc), identifier), opt(spbr)),
+            opt(terminated(implements_clause, opt(spbrc))),
             enum_body,
         )),
     )
@@ -53,11 +53,14 @@ where
             pair(tag("{"), opt(spbr)),
             cut(terminated(
                 pair(
-                    sep_list(
-                        0,
-                        SepMode::AllowTrailing,
-                        pair(tag(","), opt(spbr)),
-                        terminated(with_meta(enum_value), opt(spbrc)),
+                    terminated(
+                        sep_list(
+                            0,
+                            SepMode::AllowTrailing,
+                            pair(tag(","), opt(spbr)),
+                            terminated(with_meta(enum_value), opt(spbrc)),
+                        ),
+                        opt(spbrc),
                     ),
                     alt((
                         preceded(

--- a/dart-parser/src/parser/expr.rs
+++ b/dart-parser/src/parser/expr.rs
@@ -23,15 +23,18 @@ pub fn expr<'s, E>(s: &'s str) -> PResult<Expr, E>
 where
     E: ParseError<&'s str> + ContextError<&'s str>,
 {
-    recognize(
-        // Make sure something other than whitespace is consumed
-        preceded(opt(spbr), expr_body),
+    context(
+        "expr",
+        recognize(
+            // Make sure something other than whitespace is consumed
+            preceded(opt(spbr), expr_body),
+        )
+        .and_then(alt((
+            terminated(identifier, eof).map(Expr::Ident),
+            terminated(string, eof).map(Expr::String),
+            |s: &'s str| Ok((&s[s.len()..], Expr::Verbatim(s))),
+        ))),
     )
-    .and_then(alt((
-        terminated(identifier, eof).map(Expr::Ident),
-        terminated(string, eof).map(Expr::String),
-        |s: &'s str| Ok((&s[s.len()..], Expr::Verbatim(s))),
-    )))
     .parse(s)
 }
 

--- a/dart-parser/src/parser/maybe_required.rs
+++ b/dart-parser/src/parser/maybe_required.rs
@@ -1,0 +1,32 @@
+use nom::{
+    branch::alt,
+    bytes::complete::tag,
+    combinator::{opt, success},
+    error::{context, ContextError, ParseError},
+    sequence::terminated,
+    Parser,
+};
+
+use crate::dart::MaybeRequired;
+
+use super::{common::spbrc, PResult};
+
+pub fn maybe_required<'s, P, T, E>(mut p: P) -> impl FnMut(&'s str) -> PResult<MaybeRequired<T>, E>
+where
+    P: Parser<&'s str, T, E>,
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    context("maybe_required", move |s| {
+        let (s, is_required) = terminated(is_required, opt(spbrc))(s)?;
+        let (s, value) = p.parse(s)?;
+
+        Ok((s, MaybeRequired::new(is_required, value)))
+    })
+}
+
+fn is_required<'s, E>(s: &'s str) -> PResult<bool, E>
+where
+    E: ParseError<&'s str> + ContextError<&'s str>,
+{
+    alt((tag("required").map(|_| true), success(false)))(s)
+}


### PR DESCRIPTION
+ Parse mix-in-on clause
+ Parse tuples with positional and named fields
+ Improve func-call annotation parsing
+ Use `spbrc()` more extensively

Resolves #62 