### PR TITLE
Parse user-defined operators

### DIFF
--- a/dart-parser/src/dart/func_like.rs
+++ b/dart-parser/src/dart/func_like.rs
@@ -5,6 +5,7 @@ use super::{ty::Type, Expr, MaybeRequired, TypeParam, WithMeta};
 #[derive(PartialEq, Eq, Debug)]
 pub enum FuncLike<'s> {
     Func(Func<'s>),
+    Operator(Operator<'s>),
     Getter(Getter<'s>),
     Setter(Setter<'s>),
 }
@@ -17,6 +18,46 @@ pub struct Func<'s> {
     pub type_params: Vec<TypeParam<'s>>,
     pub params: FuncParams<'s, FuncParam<'s>>,
     pub body: Option<FuncBody<'s>>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct Operator<'s> {
+    pub modifiers: FuncModifierSet,
+    pub return_type: Type<'s>,
+    pub operator_type: UserDefOperator,
+    pub type_params: Vec<TypeParam<'s>>,
+    pub params: FuncParams<'s, FuncParam<'s>>,
+    pub body: Option<FuncBody<'s>>,
+}
+
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
+pub enum UserDefOperator {
+    Lt,
+    Lte,
+    Gt,
+    Gte,
+    /// Could mean negation or subtraction, depending on the signature.
+    Minus,
+    Add,
+    Div,
+    DivInt,
+    Mul,
+    Mod,
+    Pipe,
+    Caret,
+    Amp,
+    /// `<<`
+    LShift,
+    /// `>>`
+    RShift,
+    /// `>>>`
+    RShiftTri,
+    /// `[]`
+    IndexGet,
+    /// `[]=`
+    IndexSet,
+    Tilde,
+    Eq,
 }
 
 #[derive(PartialEq, Eq, Debug)]

--- a/dart-parser/src/parser/common.rs
+++ b/dart-parser/src/parser/common.rs
@@ -1,6 +1,7 @@
 use nom::{
     branch::alt,
     bytes::complete::{is_a, tag},
+    character::complete::one_of,
     combinator::recognize,
     error::{ContextError, ParseError},
     multi::{fold_many0, fold_many1},
@@ -120,6 +121,10 @@ where
 /// Parse one or more whitespace characters, including line breaks.
 pub fn spbr<'s, E: ParseError<&'s str>>(s: &'s str) -> PResult<&str, E> {
     is_a(" \t\r\n")(s)
+}
+
+pub fn spbr_char<'s, E: ParseError<&'s str>>(s: &'s str) -> PResult<char, E> {
+    one_of(" \t\r\n")(s)
 }
 
 /// Parse exactly one line break.

--- a/dart-parser/src/parser/expr.rs
+++ b/dart-parser/src/parser/expr.rs
@@ -126,10 +126,18 @@ mod tests {
     }
 
     #[test]
-    fn expr_list_test() {
+    fn expr_typed_list_test() {
         assert_eq!(
             expr::<VerboseError<_>>("<String>['asdf', 'jkl;']; "),
             Ok(("; ", Expr::Verbatim("<String>['asdf', 'jkl;']")))
+        );
+    }
+
+    #[test]
+    fn expr_list_test() {
+        assert_eq!(
+            expr::<VerboseError<_>>("[\n'asdf',\n'jkl;'\n]; "),
+            Ok(("; ", Expr::Verbatim("[\n'asdf',\n'jkl;'\n]")))
         );
     }
 

--- a/dart-parser/src/parser/ty.rs
+++ b/dart-parser/src/parser/ty.rs
@@ -346,6 +346,14 @@ mod tests {
     use super::*;
 
     #[test]
+    fn identifier_test() {
+        assert_eq!(
+            identifier::<VerboseError<_>>("externalSource "),
+            Ok((" ", "externalSource"))
+        );
+    }
+
+    #[test]
     fn type_args_test() {
         assert_eq!(
             type_args::<VerboseError<_>>("<void Function()>x"),


### PR DESCRIPTION
+ Parse user-defined operators
+ Make sure var modifier parser doesn't dig into the var name

Resolves #44 